### PR TITLE
A little fix for SRM's zh-cn localization

### DIFF
--- a/locale/zh_cn/local_module.srmap.sii
+++ b/locale/zh_cn/local_module.srmap.sii
@@ -182,7 +182,7 @@ localization_db : .localization
 		val[]: "皮莱尔什涅"
 
 		key[]: "rostov"
-		val[]: "顿河罗斯托夫"
+		val[]: "顿河畔罗斯托夫"
 
 		key[]: "sem_sk"
 		val[]: "西米卡拉克斯克"


### PR DESCRIPTION
Hi iMarbot,
This is a little change. I replaced Rostov-on-Don's Chinese (Simplified) localization "顿河罗斯托夫" with the correct translate "顿河畔罗斯托夫".